### PR TITLE
[Hotfix] 예약 취소 시 hiveAction 데이터 영구 삭제

### DIFF
--- a/src/domain/hive-report/entities/hive-action.entity.ts
+++ b/src/domain/hive-report/entities/hive-action.entity.ts
@@ -8,7 +8,6 @@ import { Reward } from './reward.entity';
 @Entity('hive_action')
 export class HiveAction extends BaseEntity {
   @ManyToOne(() => HiveReport, (r) => r.actions, {
-    cascade: ['insert'],
     nullable: false,
   })
   @JoinColumn()

--- a/src/domain/hive-report/entities/hive-report.entity.ts
+++ b/src/domain/hive-report/entities/hive-report.entity.ts
@@ -7,7 +7,9 @@ import { HiveAction } from './hive-action.entity';
 
 @Entity('hive_report')
 export class HiveReport extends BaseEntity {
-  @OneToMany(() => HiveAction, (a) => a.hiveReport, { cascade: true })
+  @OneToMany(() => HiveAction, (a) => a.hiveReport, {
+    cascade: true,
+  })
   actions: HiveAction[];
 
   @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })

--- a/src/domain/hive-report/hive-report.service.ts
+++ b/src/domain/hive-report/hive-report.service.ts
@@ -253,11 +253,8 @@ export class HiveReportService {
       }
 
       report.status = HiveReportStatus.REPORTED;
-      const action = manager.create(HiveAction, {
-        member: beekeeper,
-        actionType: HiveActionType.CANCEL_RESERVE,
-      });
-      report.actions.push(action);
+      await manager.getRepository(HiveAction).delete(reserveAction.id);
+      report.actions = report.actions.filter((a) => a.id !== reserveAction.id);
       await manager.save(report);
     });
   }


### PR DESCRIPTION
## 🍯 수정된 부분

- 기존 : 예약 취소 시 CANCEL_RESERVATION action 추가
- 변경 : 예약 취소 시 해당 RESERVE action 영구 삭제


<br/><br/>

## 🍯 구현 기술의 동작 방식 및 도입 이유

### 예약 취소 시 해당 RESERVE 타입의 hiveAction 데이터는 영구 삭제합니다.
- 하나의 hiveReport 에는 여러개의 hiveAction 이 존재합니다.
- 꿀벌집의 경우 REPORT, RESERVE, HONEYBEE_PROOF 가 하나씩 존재할 수 있습니다.
- 말벌집의 경우 REPORT, WASP_PROOF 가 하나씩 존재할 수 있습니다.

꿀벌집 액션 중 CANCEL_RESERVE 를 관리해서 취소된 예약 데이터를 저장하려 했으나, 화면 구현상 필요하지 않기도 하고 데이터 메모리나 안정성 측면에서도 아직 불필요한 것 같아 삭제합니다.
만약 취소된 예약 데이터가 필요하다면 추가 가능합니다.

#### 구현 이유
- 화면 구현 상 취소한 예약은 구현되지 않기 때문에 예약취소 관련 데이터는 보존하지 않기로 결정했습니다.

<br/>