### PR TITLE
[Fix] 벌집 제거 인증에 말벌집 제거 인증 추가

### DIFF
--- a/src/domain/hive-report/hive-report.controller.ts
+++ b/src/domain/hive-report/hive-report.controller.ts
@@ -77,7 +77,7 @@ export class HiveReportController {
   @Get('me')
   @ApiOperation({ summary: '나의 벌집 신고서 조회' })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
-  @ApiQuery({ name: 'size', required: false, type: Number, example: 20 })
+  @ApiQuery({ name: 'size', required: false, type: Number, example: 100 })
   @ApiQuery({
     name: 'statusFilter',
     required: false,

--- a/src/domain/member/dto/member-response.dto.ts
+++ b/src/domain/member/dto/member-response.dto.ts
@@ -13,4 +13,10 @@ export class MemberResponseDto extends CreateMemberDto {
     example: 'BEEKEEPER',
   })
   role?: string;
+
+  @ApiProperty({
+    description: '회원 리워드',
+    example: '100',
+  })
+  points: number;
 }

--- a/src/domain/member/member.controller.ts
+++ b/src/domain/member/member.controller.ts
@@ -29,6 +29,7 @@ export class MemberController {
       nickname: member.nickname,
       profileImageUrl: member.profileImageUrl,
       role: member.role,
+      points: member.points,
     };
   }
 


### PR DESCRIPTION
## 🍯 수정된 부분

- 벌집 제거 인증에 말벌집 제거 인증 추가
- 벌집신고서 상세조회에 벌집 제거한 사람 정보 추가
- 마이페이지 호출 시 리워드 점수 반환

<br/><br/>

## 🍯 구현 기술의 동작 방식 및 도입 이유

### 벌집 제거 인증에 말벌집 제거 인증 추가
> 신고자도 같은 엔드포인트로 벌집제거인증 요청을 보낼 수 있도록 수정합니다.

#### 구현 이유
1. 신고자도 같은 엔드포인트로 벌집제거인증 요청을 보낼 수 있도록 수정합니다.
2. 양봉업자의 경우 본인이 예약한 꿀벌집신고서에만 제거 요청을 보낼 수 있습니다.
3. 신고자의 경우 본인이 신고한 말벌집신고서에만 제거요청을 보낼 수 있습니다.
4. 이외의 모든 상황은 예외처리 됩니다.

<br/>

### 벌집신고서 상세조회에 벌집 제거한 사람 정보 추가

- 기존: 벌집을 예약한 사람만 정보가 보였음.
- 변경: 벌집을 제거한 경우 제거한 양봉업자의 정보를 보여줌 (말벌집의 경우 둘다 본인의 정보임)

<br/>

### 마이페이지 호출 시 리워드 점수 반환
> 마이페이지에 본인의 리워드 점수도 반환합니다.

- 우선 양봉업자도 포인트 주는 방식으로 구현하겠습니다. (나중에 필요할 수도 있으니,,)

<br/>