### PR TITLE
[Feature] 지도용 전체 벌집신고서 데이터 반환 구현

### DIFF
--- a/src/domain/hive-report/dto/hive-report-pin.dto.ts
+++ b/src/domain/hive-report/dto/hive-report-pin.dto.ts
@@ -1,0 +1,9 @@
+import { PickType } from '@nestjs/mapped-types';
+import { HiveReportDetailResponseDto } from './hive-report-detail-response.dto';
+
+export class HiveReportPinDto extends PickType(HiveReportDetailResponseDto, [
+  'hiveReportId',
+  'latitude',
+  'longitude',
+  'species',
+]) {}

--- a/src/domain/hive-report/hive-report.controller.ts
+++ b/src/domain/hive-report/hive-report.controller.ts
@@ -36,12 +36,30 @@ import { PaginatedDto } from '../../common/dto/paginated.dto';
 import { HiveReportDetailResponseDto } from './dto/hive-report-detail-response.dto';
 import { CreateProofDto } from './dto/create-proof.dto';
 import { HiveProofResponseDto } from './dto/hive-proof-response.dto';
+import { HiveReportPinDto } from './dto/hive-report-pin.dto';
 
 @Controller('hive-reports')
 @UseGuards(JwtAccessGuard, MemberRoleGuard)
 @ApiBearerAuth('jwt-access')
 export class HiveReportController {
   constructor(private readonly hiveReportService: HiveReportService) {}
+
+  @Get()
+  @ApiOperation({ summary: '지도 표시 용 벌집 신고서 조회' })
+  @ApiResponse({ status: 2000, description: '성공적으로 조회되었습니다.' })
+  async getReports(
+    @Query('minLat') minLat?: string,
+    @Query('maxLat') maxLat?: string,
+    @Query('minLng') minLng?: string,
+    @Query('maxLng') maxLng?: string,
+  ): Promise<HiveReportPinDto[]> {
+    return this.hiveReportService.findReportsInBounds(
+      minLat ? parseFloat(minLat) : undefined,
+      maxLat ? parseFloat(maxLat) : undefined,
+      minLng ? parseFloat(minLng) : undefined,
+      maxLng ? parseFloat(maxLng) : undefined,
+    );
+  }
 
   @Post('image')
   @UseInterceptors(FileInterceptor('file'))

--- a/src/domain/hive-report/hive-report.service.ts
+++ b/src/domain/hive-report/hive-report.service.ts
@@ -21,6 +21,8 @@ import { HiveReportDetailResponseDto } from './dto/hive-report-detail-response.d
 import { CreateProofDto } from './dto/create-proof.dto';
 import { Reward } from './entities/reward.entity';
 import { Member } from '../member/entities/member.entity';
+import { HiveReportPinDto } from './dto/hive-report-pin.dto';
+import { HiveProofResponseDto } from './dto/hive-proof-response.dto';
 
 @Injectable()
 export class HiveReportService {
@@ -325,7 +327,7 @@ export class HiveReportService {
     memberId: string,
     proofDto: CreateProofDto,
     imageUrl: string,
-  ) {
+  ): Promise<HiveProofResponseDto> {
     const { actionType, latitude, longitude } = proofDto;
     return await this.dataSource.transaction(async (manager) => {
       const member = await manager
@@ -415,5 +417,44 @@ export class HiveReportService {
         imageUrl,
       };
     });
+  }
+
+  async findReportsInBounds(
+    minLat?: number,
+    maxLat?: number,
+    minLng?: number,
+    maxLng?: number,
+  ): Promise<HiveReportPinDto[]> {
+    const qb = this.hiveReportRepo
+      .createQueryBuilder('report')
+      .select([
+        'report.id',
+        'report.latitude',
+        'report.longitude',
+        'report.species',
+      ]);
+
+    if (
+      minLat !== undefined &&
+      maxLat !== undefined &&
+      minLng !== undefined &&
+      maxLng !== undefined
+    ) {
+      qb.where('report.latitude BETWEEN :minLat AND :maxLat', {
+        minLat,
+        maxLat,
+      }).andWhere('report.longitude BETWEEN :minLng AND :maxLng', {
+        minLng,
+        maxLng,
+      });
+    }
+
+    const reports = await qb.getMany();
+    return reports.map((report) => ({
+      hiveReportId: report.id,
+      latitude: report.latitude,
+      longitude: report.longitude,
+      species: report.species,
+    }));
   }
 }


### PR DESCRIPTION
## 🍯 수정된 부분

- 지도에 표시될 벌집신고서 요약 데이터 리스트를 반환

<br/><br/>

## 🍯 구현 기술의 동작 방식 및 도입 이유

### 지도에 표시하기 위한 벌집신고서 핀 정보 리스트를 반환합니다.
> id, 위치, 벌집종류 를 반환합니다.

- 추가로 bounds 정보 (minLat, maxLat, minLng, maxLng) 를 받아서 줌 정도에 따라 필요한 데이터만 반환하는 방식도 구현했습니다.

<br/>