### PR TITLE
[Feature] 회원가입 시 알림 샘플 알림데이터 저장

### DIFF
--- a/src/domain/hive-report/hive-report.service.ts
+++ b/src/domain/hive-report/hive-report.service.ts
@@ -542,7 +542,7 @@ export class HiveReportService {
         const notification = notiRepo.create({
           member: reporter,
           title: '꿀벌집 제거 완료!',
-          body: '꿀벌집이 성공적으로 제거되었습니다.',
+          body: '꿀벌집이 안전하게 제거되었습니다.',
           data: { hiveReportId },
           type: NotificationType.HONEYBEE_REMOVED,
           hiveReport: { id: hiveReportId } as HiveReport,


### PR DESCRIPTION
## 🍯 구현 기술의 동작 방식 및 도입 이유

### 꿀벌집 제거 시 신고자에게 알림 발생
> 말벌집은 알림 없습니다.

<br/>

### 회원가입 시 알림 샘플 데이터 저장
> 각 역할의 상황에 맞는 알림 저장합니다.

<br/>

## 🍯 해당 기술에 추가될 작업 내용

- 안드로이드에서 테스트 할 예정입니다.

<br/>